### PR TITLE
bugfix: update renderSemaphore() object property logic

### DIFF
--- a/script/signalHandler.js
+++ b/script/signalHandler.js
@@ -7,7 +7,7 @@ let rightFlag = document.getElementById('right-flag');
 
 function renderSemaphore(key) {
     key = key.toLowerCase();
-    if (semaphores[key]) {
+    if (key in semaphores) {
 
         if (key == 'h' || key == 'i' || key == 'o') {
             leftFlag.setAttribute('class', 'flip-flag');


### PR DESCRIPTION
This commit intended to improve the object property check logic for semaphores object in renderSemaphore(), following change was made,
- remove semaphores[key] and replaced it with "key in semaphores"